### PR TITLE
updating main index and ios index for v1.0 release prep

### DIFF
--- a/frankly-ios/index.html
+++ b/frankly-ios/index.html
@@ -20,7 +20,7 @@
 	<h1>
 		Frankly iOS SDK Integration Guide
 	</h1>
-<p><i>Last updated May 18, 2015</i></p>
+<p><i>Last updated June 09, 2015</i></p>
 
 <br>
 <br>
@@ -37,6 +37,7 @@
 		</ul>
 		<li><a href="#initializing">Initializing the SDK</a>
 		<li><a href="#authenticating">Authenticating the Client</a>
+		<li><a href="#setting_displayname_and_avatar">Programmatically Setting User Display Names & Profile Avatars</a>
 		<li><a href="#set_up_first_room_list">Setting Up Your First Room List</a>
 		<li><a href="#log_in">Allowing the User to Log In or Sign Up</a>
 	</ul>
@@ -93,8 +94,10 @@
 			<li><pre><code>Foundation.framework</pre></code>
 			<li><pre><code>CoreData.framework</pre></code>
 			<li><pre><code>SystemConfiguration.framework</pre></code>
-			<br><br> <img src="../images/ios_sdk_xcode_installation_2.png" border="1"> <br><br><br>
 		</ul>
+		
+		<br><br> <img src="../images/ios_sdk_xcode_installation_2.png" border="1"> <br><br><br>
+		
 		<li>Update your project’s Build Settings by accessing the Build Settings tab in the Project File. Make sure your filter is set to All. Search for Other Linker Flags and set it to “<code>-ObjC</code>”
 			<br><br> <img src="../images/ios_sdk_xcode_installation_3.png" border="1"> <br><br><br>
 
@@ -143,7 +146,7 @@
 	</h2>
 
 <p>
-	Now it’s time to set up authenticating the client.
+	Now it’s time to set up client authentication.
 </p>
 
 	<ol>	
@@ -151,7 +154,7 @@
 <p>In our example code, we’ve made our <code>ViewController</code> conform to the protocol</p>
 
 <pre><code>
-	@interface ViewController : UIViewController <FranklySDKAuthenticationDelegate>
+	@interface ViewController : UIViewController &lt;FranklySDKAuthenticationDelegate&gt;
 </code></pre>
 
 		<li>You set the FranklySDK authenticationDelegate and initiate authentication as follows:
@@ -161,7 +164,7 @@
 
 	[super viewDidLoad];
 
-	[FranklySDK sharedInstance].authenticationDelegate = <delegate object>;
+	[FranklySDK sharedInstance].authenticationDelegate = self;
 
 	[[FranklySDK sharedInstance] initiateAuthentication];
 
@@ -183,8 +186,8 @@ This method is where you should utilize your back end server as detailed in Fran
 							<li>Your Auth Key and Auth Secret can be found within the Admin Console under Settings
 						</ul>
 					</ul>
-					<li><code>authenticationDidSucceed()</code> - After this message is received, you may use the SDK.
-					<li><code>authenticationDidFailWithError()</code> - If this message is received, you need to start authentication process over before you may use the SDK. 
+					<li><code>authenticationDidSucceedWithUserID:(NSNumber*)</code> - After this message is received, you may use the SDK.
+					<li><code>authenticationDidFailWithError:(NSError*)</code> - If this message is received, you need to start authentication process over before you may use the SDK. 
 
 <pre><code>
 - (void)identifierWithNonce:(NSString *)nonce completion:(void (^)(NSString *identifier))completion {
@@ -207,7 +210,7 @@ This method is where you should utilize your back end server as detailed in Fran
 <br>
 
 <pre><code>
-- (void)authenticationDidSucceed {
+- (void)authenticationDidSucceedWithUserID:(NSNumber *)userID {
 
 	NSLog(@"authentication did succeed");
 
@@ -220,7 +223,6 @@ This method is where you should utilize your back end server as detailed in Fran
 - (void)authenticationDidFailWithError:(NSError *)error {
 
 	NSLog(@"authentication did fail");
-
 }
 </code></pre>
 
@@ -230,6 +232,59 @@ This method is where you should utilize your back end server as detailed in Fran
 
 					<li>Try running the build
 </ol>
+</a>
+
+<br>
+<br>
+
+<a id="setting_displayname_and_avatar">
+	<h2>
+		Programmatically Setting User Display Names & Profile Avatars
+	</h2>
+
+<p>
+
+	<ol>			
+			<li>Set the FranklySDK’s <code>profileDelegate</code> to an object that conforms to the <code>FranklySDKUserProfileDelegate</code> protocol.
+				
+				<br><br>
+				
+			<p>In our example code, we’ve made our <code>ViewController</code> also conform to this protocol</p>
+
+			<pre><code>
+				@interface ViewController : UIViewController &lt;FranklySDKAuthenticationDelegate, FranklySDKUserProfileDelegate&gt;
+			</code></pre>
+
+			<pre><code>
+			- (void)viewDidLoad {
+
+				[super viewDidLoad];
+
+				[FranklySDK sharedInstance].authenticationDelegate = self;
+				[FranklySDK sharedInstance].profileDelegate = self;				
+
+				[[FranklySDK sharedInstance] initiateAuthentication];
+			}
+			</code></pre>
+			
+			The profile delegate will get called every time the user profile image or display name changes.  Also, you can enable or disable user editing of their
+			profile data within the FranklySDK UI by allowing your delegate respond appropriately to the <code>-(BOOL)shouldAllowProfileEditing</code> delegate request.  
+			
+			<br><br>
+
+			<li>Setting the user's display name and avatar can be done via the calls through the FranklySDK object
+			
+			<pre><code>
+
+				-(void)setUserName:(NSString *)userName profileImage:(UIImage *)image];
+
+			</code></pre>
+			
+			<li>When the user name and image have been updated and synced with the server the profileDelegate will get a called back that they have been changed. 
+					
+	</ol>
+
+</p>
 </a>
 
 <br>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@ This is the home for all documentation available to help you integrate with the 
 	</h2>	
 	
 	<ul>
-		<li><i>Coming Soon! Admin Console</i>
 		<li><a href="frankly-server-auth/index.html">Server Authentication</a>
 		<li><a href="frankly-ios/index.html">iOS SDK Integration Guide</a>
 		<li><a href="frankly-android/index.html">Android SDK Integration Guide</a>
@@ -73,11 +72,11 @@ This is the home for all documentation available to help you integrate with the 
 <body>
 	
 	<h2>
-		Support
+		Access & Support
 	</h2>
 	
 	<p>
-		Need help with integrating with Frankly Platform? Interested in developing on the Frankly Platform but not sure how to get access? Contact us at <a href="mailto:platform-support@franklychat.com">platform-support@franklychat.com</a>.
+		Interested in developing on the Frankly Platform but not sure how to get access? Need help with integrating with Frankly Platform? Contact us at <a href="mailto:platform-support@franklychat.com">platform-support@franklychat.com</a>.
 	</p>
 </body>
 </html>


### PR DESCRIPTION
@pavitrabhalla - Here's a summary of my changes:
1. Main Index
   - Removed 'Coming Soon' reference for Admin Console guide (we should handle Admin Console education differently in the future).
   - Updated "Support" section ==> "Access & Support" to better address potential questions since Admin Console signup isn't available publicly.
2. iOS SDK Index
   - Updated references to initialization of SDK
   - Updated references to authenticating the client
   - Added a section describing how to update users' Display Names and Profile Avatars via the client
