### PR TITLE
Fix responsive header by defining view port scale

### DIFF
--- a/APIReference.html
+++ b/APIReference.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>API Reference</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/AdvancedIntegrations.html
+++ b/AdvancedIntegrations.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Advanced Integrations</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/Auth.html
+++ b/Auth.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Authenticating with Frankly</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/BasicIntegration.html
+++ b/BasicIntegration.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Basic Integration</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">
@@ -307,7 +308,7 @@ userManager.update(user);
 	<div class="pager-container">
 	<nav>
 	  <ul class="pager">
-	    <li class="previous"><a href="Auth.html"><span aria-hidden="true">&larr;</span> Authenticating with Frankly</a></li>
+	    <li class="previous"><a href="Auth.html"><span aria-hidden="true">&larr;</span> Authenticating</a></li>
 	    <li class="next"><a href="AdvancedIntegrations.html">Advanced Integrations <span aria-hidden="true">&rarr;</span></a></li>
 	  </ul>
 	</nav>

--- a/InitializeSDK.html
+++ b/InitializeSDK.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Initializing the SDK</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">
@@ -234,7 +235,7 @@ android.permission.READ_EXTERNAL_STORAGE
 	<nav>
 	  <ul class="pager">
 	    <li class="previous"><a href="InstallSDK.html"><span aria-hidden="true">&larr;</span> Installing the SDK</a></li>
-	    <li class="next"><a href="Auth.html">Authenticating with Frankly <span aria-hidden="true">&rarr;</span></a></li>
+	    <li class="next"><a href="Auth.html">Authenticating<span aria-hidden="true">&rarr;</span></a></li>
 	  </ul>
 	</nav>
 	</div>

--- a/InstallSDK.html
+++ b/InstallSDK.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Installing the SDK</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/Support.html
+++ b/Support.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Support</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/css/main.css
+++ b/css/main.css
@@ -109,7 +109,7 @@ nav.navbar {
 /*For Index Body*/
 .doc {
 	position: relative;
-	width: 90%;
+
 	padding-top: 20px;
 	padding-bottom: 20px;
     font-family: 'Roboto', sans-serif;
@@ -124,6 +124,9 @@ nav.navbar {
 	text-decoration: none;
 }
 
+img {
+	max-width: 100%;
+        }
 
 /*For Wells*/
 .well-bottom-nav {

--- a/css/main.css
+++ b/css/main.css
@@ -109,7 +109,6 @@ nav.navbar {
 /*For Index Body*/
 .doc {
 	position: relative;
-
 	padding-top: 20px;
 	padding-bottom: 20px;
     font-family: 'Roboto', sans-serif;

--- a/css/main.css
+++ b/css/main.css
@@ -1,7 +1,6 @@
 /*For Main Index Header*/
 .header {
 	position: relative;
-	width: 80%;
 	padding-top: 20px;
 	padding-bottom: 20px;
 	font-family: 'Roboto', sans-serif;

--- a/downloads.html
+++ b/downloads.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Downloads</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>The Frankly Developer Portal</title>
     <meta name="keywords" content="Frankly Platform" />
+	<meta name="viewport" content="width=device-width, initial-scale=1"/>
     <link type="text/css" rel="stylesheet" href="css/main.css">
     <link type="text/css" rel="stylesheet" href="css/bootstrap.css">	
     <link rel="stylesheet" type="text/css">


### PR DESCRIPTION
@pavitrabhalla worked with Damien to address (what we believe to be) the final responsiveness issues.

**Changes**
1. Added 1 line to each page to specify the scale for the viewport (so that our min/max screen size settings would have an impact when viewing on mobile devices)
2. Made a couple tiny content changes to fix display of bottom nav buttons

**Test Plan**
1. Tested this on the latest Chrome for Mac + discovered the mobile device simulator to make sure everything works nicely on Chrome for iOS (which it does look nice)
2. Tested this in mobile Safari in the iOS Simulator and it looks nice
