### PR TITLE
Updated Downloads Page w/ Link to iOS SDK v1.1.2 Fat Binary

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -86,8 +86,8 @@
 	<div class="doc">
 	
 		<div class="list-group">
-		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/ios/fat/frankly-sdk-ios-1.1.1-fat.zip" download class="list-group-item">Frankly iOS SDK v1.1.1 (fat)</a>
-		  <a href="InstallSDK.html#Installing_iOS" download class="list-group-item">Frankly iOS SDK (CocoaPods) <i>Please see 'Installing the SDK' for more info</i></a>
+		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/ios/fat/frankly-sdk-ios-1.1.2-fat.zip" download class="list-group-item">Frankly iOS SDK v1.1.2 (fat)</a>
+		  <a href="InstallSDK.html#Installing_iOS" class="list-group-item">Frankly iOS SDK (CocoaPods) <i>Please see 'Installing the SDK' for more info</i></a>
 		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/android/frankly-sdk-android-1.1.0.zip" download class="list-group-item">Frankly Android SDK v1.1.0 (Android Studio)</a>
 		  <a href="https://github.com/franklyinc/frankly-js" target="_blank" class="list-group-item">Frankly JavaScript SDK</a>
 		  <a href="https://github.com/franklyinc/frankly-python" target="_blank" class="list-group-item">Frankly Python Module</a>

--- a/index.html
+++ b/index.html
@@ -82,16 +82,14 @@
 
 
 	<div class="jumbotron">
-	  <h2>Frankly SDK v1 launched!</h2>
-	  <h5><i>June 16, 2015</i></h5>
+	  <h2>Frankly SDK v1.1.0 launched!</h2>
+	  <h5><i>July 1, 2015</i></h5>
 	  <br>
-	  <p>We've just release v1.0.0 of the Frankly iOS and Android SDKs. These SDKs provide the core foundation for integrating chat in your brand's application.</p>
+	  <p>We've just released v1.1.2 of the Frankly iOS SDK and v1.1.0 of the Android SDK. These SDKs provide the core foundation for integrating chat in your brand's application + the introduction of Guest Mode and lots of great performance improvements.</p>
 	  <p><a class="btn btn-primary btn-lg" href="downloads.html" role="button">Download Now!</a></p>
 	</div>
 
 <br>
-
-
 
 	<div class="doc">
 	


### PR DESCRIPTION
@pavitrabhalla 

**Changes**
1. I updated the download link for the iOS SDK v1.1.2 Fat binary on the Downloads page and
2. Updated the information on the jumbotron UI of the main Index to reflect the updated SDKs from today and last week
