### PR TITLE
Updating iOS SDK download links + ref to v1.1.4

### DIFF
--- a/InstallSDK.html
+++ b/InstallSDK.html
@@ -19,7 +19,7 @@
 	<script> 
 	var frankly_menu = [
 	'<ul>',
-		'<li><a href="index.html">Getting Started</a></li>',
+		'<li><a href="http://franklyinc.github.io">Getting Started</a></li>',
 		'<li><a href="InstallSDK.html">Installing the SDK</a>',
 			'<ul>',
 				'<li><a href="#Installing_iOS">iOS SDK</a></li>',
@@ -84,7 +84,9 @@
 			Installing the SDK
 		</h1>
 
-	<br>
+
+<br>
+
 	
 			<ul>
 				<li><a href="#Installing_iOS">iOS SDK</a>
@@ -94,11 +96,10 @@
 
 	</div>
 
-	<br>
-	<br>
 
-		
-	<!-- This needs to be cleaned up -->
+<br>
+<br>
+
 
 	<div class="doc">
 			<a id="Installing_iOS">

--- a/Support.html
+++ b/Support.html
@@ -91,7 +91,7 @@
 				Interested in developing on the Frankly Platform but not sure how to get access? Need help with integrating with Frankly Platform? Contact us at <a href="mailto:platform-support@franklychat.com">platform-support@franklychat.com</a>.
 			</p>
 
-	<br>
+<br>
 
 	<!--
 		<a id="Reporting">
@@ -107,6 +107,5 @@
 	
 
 	</div>
-</div>
 	
 </html>

--- a/downloads.html
+++ b/downloads.html
@@ -86,8 +86,8 @@
 	<div class="doc">
 	
 		<div class="list-group">
-		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/ios/fat/frankly-sdk-ios-1.1.3-fat.zip" download class="list-group-item">Frankly iOS SDK v1.1.3 (fat)</a>
-		  <a href="InstallSDK.html#cocoapods" class="list-group-item">Frankly iOS SDK v1.1.3 (CocoaPods) <i>Please see 'Installing the SDK' for more info</i></a>
+		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/ios/fat/frankly-sdk-ios-1.1.4-fat.zip" download class="list-group-item">Frankly iOS SDK v1.1.4 (fat)</a>
+		  <a href="InstallSDK.html#cocoapods" class="list-group-item">Frankly iOS SDK v1.1.4 (CocoaPods) <i>Please see 'Installing the SDK' for more info</i></a>
 		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/android/frankly-sdk-android-1.1.0.zip" download class="list-group-item">Frankly Android SDK v1.1.0 (Android Studio)</a>
 		  <a href="https://github.com/franklyinc/frankly-js" target="_blank" class="list-group-item">Frankly JavaScript SDK</a>
 		  <a href="https://github.com/franklyinc/frankly-python" target="_blank" class="list-group-item">Frankly Python Module</a>


### PR DESCRIPTION
@pavitrabhalla everything else besides what's mentioned in the title is just cleaning up some test code. Ultimately not shipping anything besides the updated v1.1.4 iOS SDK link + refs.
