### PR TITLE
Added install guides for the Python + Ruby SDKs and refs for JS SDK v1.0.0

### DIFF
--- a/AdvancedIntegrations.html
+++ b/AdvancedIntegrations.html
@@ -292,7 +292,7 @@ gem 'frankly-ruby', :git => 'git://github.com/franklyinc/frankly-ruby.git'
 		</p>
 		
 <pre class="prettyprint"><code>
-bundle install
+$ bundle install
 </code></pre>
 
 

--- a/AdvancedIntegrations.html
+++ b/AdvancedIntegrations.html
@@ -28,6 +28,7 @@
 			'<ul>',
 				'<li><a href="#Open_Room">Directly Opening a Room</a></li>',
 				'<li><a href="#Server_APIs">Server API Access</a></li>',
+				'<li><a href="#Installing_ServerSDKs">Server SDKs</a></li>',
 				'<li><a href="#Indepth_Usage">Indepth Usage</a></li>',
        			    '<ul>',
 				        '<li><a href="#Authentication">Authentication</a></li>',
@@ -98,6 +99,7 @@
 			<ul>
 				<li><a href="#Open_Room">Directly Opening a Room</a>
 				<li><a href="#Server_APIs">Server API Access</a>
+				<li><a href="#Installing_ServerSDKs">Server SDKs</a></li>
 				<li><a href="#In-depth_Usage">In-depth Usage</a>
        			    <ul>
 				        <li><a href="#Authentication">Authentication</a></li>
@@ -184,11 +186,131 @@ context.startActivity(intent);
 		</a>
 	
 		<p>
-			The sections below describes how developers are able to interact direction with Frankly's server APIs to create more custom integrations on the Frankly Platform. To provide a clean interface for develoeprs to interact with Frankly's server APIs, we're providing a Python module and Ruby gem that are meant to easily be integrated with your existing backend stack. In the event that you need access to Frankly's server APIs in a language that is better compatible with your backend or that you are more comfortable with, please let us know by sending an email to <a href="mailto:platform-support@franklychat.com">platform-support@franklychat.com</a>.
+			The sections below describes how developers are able to interact direction with Frankly's server APIs to create more custom integrations on the Frankly Chat Platform. To provide a clean interface for develoeprs to interact with Frankly's server APIs, we're providing a Python module and Ruby gem that are meant to easily be integrated with your existing backend stack. In the event that you need access to Frankly's server APIs in a language that is better compatible with your backend or that you are more comfortable with, please let us know by sending an email to <a href="mailto:platform-support@franklychat.com">platform-support@franklychat.com</a>.
 		</p>
 	
 <br>
 <br>
+
+
+
+		<a id="Installing_ServerSDKs">
+			<h3>
+				Installing the Server SDKs
+			</h3>
+		</a>
+
+
+<br>
+
+
+		<h4>
+			Installing the Python SDK
+		</h4>
+
+		<p>	
+			The Frankly Python module can be installed, like most Python modules, using pip:
+		</p>	
+
+
+<pre class="prettyprint"><code>
+$ pip install frankly-python
+</code></pre>
+
+<br>
+
+		<h5>
+			<b>Compatibility</b>
+		</h5>
+		
+		<p>
+			The frankly-python module requires Python 2.7.9+ or Python 3.4.0+ to be used successfully.
+		</p>
+		
+			
+<br>
+			
+			
+		<h5>
+			<b>Testing</b>
+		</h5>
+			
+		<p>
+			The test suite relies on environment variables to figure out where to connect to for tests that make API calls. You should set these three environment variables before running the tests:
+		</p>
+
+			
+<pre class="prettyprint"><code class="lang-py">
+export FRANKLY_APP_HOST=https://app.franklychat.com
+export FRANKLY_APP_KEY={app key from the Frankly Console}
+export FRANKLY_APP_SECRET={app secret from the Frankly Console}
+</code></pre>
+
+
+<br>
+
+
+		<p>
+			The easiest way to run the test suite is to use the nose python module, then run:
+		</p>
+
+<pre class="prettyprint"><code>
+$ python2 -m nose
+</code></pre>
+
+
+<br>
+
+
+<pre class="prettyprint"><code>
+$ python3 -m nose
+</code></pre>
+
+
+<br>
+<br>
+
+
+		<h4>
+			Installing the Ruby SDK
+		</h4>
+		
+		<p>
+			In your Gemfile include:
+		</p>
+		
+<pre class="prettyprint"><code class="lang-rb">
+gem 'frankly-ruby', :git => 'git://github.com/franklyinc/frankly-ruby.git'
+</code></pre>
+
+
+<br>
+
+
+		<p>
+			... then run:
+		</p>
+		
+<pre class="prettyprint"><code>
+bundle install
+</code></pre>
+
+
+<br>
+
+
+		<p>
+			To use the Frankly Ruby gem:
+		</p>
+		
+<pre class="prettyprint"><code>
+require 'frankly-ruby'
+</code></pre>
+
+
+<br>
+<br>
+
 
 		<a id="In-depth_Usage">
 			<h3>

--- a/InstallSDK.html
+++ b/InstallSDK.html
@@ -139,6 +139,7 @@ pod 'FranklySDK', '~> 1.1'
 
 <br>
 
+
 			<a id="traditional">
 				<h4>
 					Traditional Installation
@@ -286,6 +287,11 @@ dependencies {
 <pre class="prettyprint"><code>
 $ npm install frankly-js
 </code></pre>
+
+
+<br>
+<br>		
+			
 
 	</div>
 

--- a/downloads.html
+++ b/downloads.html
@@ -89,9 +89,9 @@
 		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/ios/fat/frankly-sdk-ios-1.1.4-fat.zip" download class="list-group-item">Frankly iOS SDK v1.1.4 (fat)</a>
 		  <a href="InstallSDK.html#cocoapods" class="list-group-item">Frankly iOS SDK v1.1.4 (CocoaPods) <i>Please see 'Installing the SDK' for more info</i></a>
 		  <a href="https://s3.amazonaws.com/downloads.franklychat.com/releases/android/frankly-sdk-android-1.1.0.zip" download class="list-group-item">Frankly Android SDK v1.1.0 (Android Studio)</a>
-		  <a href="https://github.com/franklyinc/frankly-js" target="_blank" class="list-group-item">Frankly JavaScript SDK</a>
-		  <a href="https://github.com/franklyinc/frankly-python" target="_blank" class="list-group-item">Frankly Python Module</a>
-		  <a href="https://github.com/franklyinc/frankly-ruby" target="_blank" class="list-group-item">Frankly Ruby Gem</a>
+		  <a href="https://github.com/franklyinc/frankly-js" target="_blank" class="list-group-item">Frankly JavaScript SDK v1.0.0</a>
+		  <a href="https://github.com/franklyinc/frankly-python" target="_blank" class="list-group-item">Frankly Python SDK</a>
+		  <a href="https://github.com/franklyinc/frankly-ruby" target="_blank" class="list-group-item">Frankly Ruby SDK</a>
 		</div>
 
 	</div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 	<script> 
 	var frankly_menu = [
 	'<ul>',
-		'<li><a href="index.html">Getting Started</a></li>',
+		'<li><a href="http://franklyinc.github.io">Getting Started</a></li>',
 		'<li><a href="InstallSDK.html">Installing the SDK</a></li>',
 		'<li><a href="InitializeSDK.html">Initializing the SDK</a></li>',
 		'<li><a href="Auth.html">Authenticating</a></li>',
@@ -82,11 +82,29 @@
 
 
 	<div class="jumbotron">
-	  <h2>Frankly SDK v1.1.0 launched!</h2>
-	  <h5><i>July 1, 2015</i></h5>
-	  <br>
-	  <p>We've just released v1.1.4 of the Frankly iOS SDK and v1.1.0 of the Android SDK. These SDKs provide the core foundation for integrating chat in your brand's application + the introduction of Guest Mode and lots of great performance improvements.</p>
-	  <p><a class="btn btn-primary btn-lg" href="downloads.html" role="button">Download Now!</a></p>
+	  
+	  <h2>
+		  Frankly SDK v1.1.0 launched!
+	  </h2>
+	  
+	  <h5>
+		  <i>July 15, 2015</i>
+	  </h5>
+	  
+<br>
+
+	  <p>
+		  We've just released v1.1.4 of the Frankly iOS SDK and v1.1.0 of the Android SDK. These SDKs provide the core foundation for integrating chat in your brand's application + the introduction of Guest Mode and lots of great performance improvements.
+	  </p>
+	  
+	  <p>
+		  We've also just released v1.0.0 of our JavaScript SDK which includes Room UI + access to all of our server API endpoints to help partners interested in integrating the Frankly Chat Platform in their web app.
+	  <p>
+	  
+	  <p>
+		  <a class="btn btn-primary btn-lg" href="downloads.html" role="button">Download Now!</a>
+	  </p>
+
 	</div>
 
 <br>


### PR DESCRIPTION
@pavitrabhalla 

**Changes**
1. Updated AdvancedIntegrations.html to add directions for installing the Python and Ruby SDKs (since I realized we were missing these in our documentation, aside from the README.md in each github repo)(verified with @mphox-frankly that the change for 1229f08 was correct)
2. The changes to InstallSDK.html can be ignored - just spacing that doesn't have an impact on anything (I thought I was going to include the Python and Ruby SDK install directions there then changed my mind but didn't remember the spacing 100%)
3. Updated downloads.html to reference the version # for the JS SDK (i.e. v1.0.0 as of yesterday)
4. Updated the jumbotron on Index.html to talk about the JS SDK v1.0.0 release
